### PR TITLE
Slurm fix

### DIFF
--- a/benchmark_analysis/benchmark_job_manager.sh
+++ b/benchmark_analysis/benchmark_job_manager.sh
@@ -60,11 +60,9 @@ for run_idx in `seq -f "%03g" ${run_idx_low} ${run_idx_high}`; do
 	
 	if [ "${scheduler}" == "slurm" ]; then
 		comm_pattern_run_stdout=$( sbatch -N ${n_nodes} -p ${queue} -J ${comm_pattern_run_name} -t ${time_limit} -n ${n_procs} --ntasks-per-node=${n_procs_per_node} ${comm_pattern_run_script} ${n_procs} ${msg_size} ${n_iters} ${proc_placement} ${run_idx} ${run_dir} ${paths_dir} ${nd_start} ${nd_iter} ${nd_end} ${impl} ${comm_pattern} ${nd_neighbor_fraction} ${x_procs} ${y_procs} ${z_procs} )
-		while [ -z "$comm_pattern_run_id" ]; do
-			comm_pattern_run_id=$( sacct -n -X --format jobid --name ${comm_pattern_run_name} )
-		done
+		comm_pattern_run_id=$( echo ${comm_pattern_run_stdout} | sed 's/[^0-9]*//g' )
 		kdts_job_deps+=${comm_pattern_run_id}
-        	comm_pattern_run_id=""
+        comm_pattern_run_id=""
 	fi
 
 	if [ "${scheduler}" == "lsf" ]; then

--- a/benchmark_analysis/benchmark_job_manager.sh
+++ b/benchmark_analysis/benchmark_job_manager.sh
@@ -60,7 +60,7 @@ for run_idx in `seq -f "%03g" ${run_idx_low} ${run_idx_high}`; do
 	
 	if [ "${scheduler}" == "slurm" ]; then
 		comm_pattern_run_stdout=$( sbatch -N ${n_nodes} -p ${queue} -J ${comm_pattern_run_name} -t ${time_limit} -n ${n_procs} --ntasks-per-node=${n_procs_per_node} ${comm_pattern_run_script} ${n_procs} ${msg_size} ${n_iters} ${proc_placement} ${run_idx} ${run_dir} ${paths_dir} ${nd_start} ${nd_iter} ${nd_end} ${impl} ${comm_pattern} ${nd_neighbor_fraction} ${x_procs} ${y_procs} ${z_procs} )
-		comm_pattern_run_id=$( echo ${comm_pattern_run_stdout} | sed 's/[^0-9]*//g' )
+		comm_pattern_run_id=$( echo ${comm_pattern_run_stdout} | sed 's/[^0-9]*//g' )" "
 		kdts_job_deps+=${comm_pattern_run_id}
         comm_pattern_run_id=""
 	fi


### PR DESCRIPTION
I have made some modifications to the "benchmark_job_manager.sh" script to address some issues with running the benchmark on tellico.

Firstly, I removed the use of 'sacct' which was causing problems due to it being disabled on tellico. Instead, I replaced it with 'sbatch', which ensures that we always get the job id, irrespective of the environment. This modification will make the benchmark script more robust and work in any environment without needing to worry about 'sacct' being enabled.

On the other hand, I fixed a bug with the job dependencies for slurm. The previous version of the script was not able to format all the job ids correctly to add as dependencies for computing the kdts. I have fixed this issue by modifying the script to correctly format all the job ids and add them as dependencies for the computation of kdts.

Overall, these changes should improve the reliability of the benchmark script on different environments and fix the bug with job dependencies on slurm.

Please consider merging my changes into the master branch. Let me know if there are any issue.